### PR TITLE
Extend timeout to 30s. Add custom error type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The main export of this package is `DevnetProvider`. Assuming you have a [runnin
 import { DevnetProvider } from "starknet-devnet";
 
 async function helloDevnet() {
-    const devnet = new DevnetProvider();
+    const devnet = new DevnetProvider(); // accepts an optional configuration object
     console.log(await devnet.isAlive()); // true
 }
 ```

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "scripts": {
         "build": "tsc -p tsconfig.build.json",
         "build-check": "tsc -p tsconfig.build.json --noEmit",
-        "test": "mocha -r ts-node/register test/**/*.ts",
+        "test": "npm run build && mocha -r ts-node/register test/**/*.ts",
         "format": "prettier --log-level log --write \"**/*.{ts,js,md,yml,json}\"",
         "format-check": "prettier --log-level log --check \"**/*.{ts,js,md,yml,json}\"",
         "lint": "eslint $(git ls-files '*.ts') --cache --fix",

--- a/src/devnet-provider.ts
+++ b/src/devnet-provider.ts
@@ -3,11 +3,13 @@ import { Postman } from "./postman";
 import { RpcProvider } from "./rpc-provider";
 import { BalanceUnit, PredeployedAccount } from "./types";
 
-const DEFAULT_HTTP_TIMEOUT = 10_000; // ms
+/** milliseconds */
+const DEFAULT_HTTP_TIMEOUT = 30_000;
 const DEFAULT_DEVNET_URL = "http://127.0.0.1:5050";
 
 export type DevnetProviderConfig = {
     url?: string;
+    /** milliseconds */
     timeout?: number;
 };
 

--- a/src/rpc-provider.ts
+++ b/src/rpc-provider.ts
@@ -1,4 +1,5 @@
 import { AxiosInstance } from "axios";
+import { DevnetProviderError } from "./types";
 
 export class RpcProvider {
     public constructor(
@@ -8,21 +9,30 @@ export class RpcProvider {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     public async sendRequest(method: string, params: unknown = {}): Promise<any> {
-        const resp = await this.httpProvider.post(this.url, {
-            jsonrpc: "2.0",
-            id: "1",
-            method,
-            params,
-        });
-
-        return new Promise((resolve, reject) => {
-            if ("result" in resp.data) {
-                resolve(resp.data["result"]);
-            } else if ("error" in resp.data) {
-                reject(resp.data["error"]);
-            } else {
-                reject(resp.data);
-            }
-        });
+        return this.httpProvider
+            .post(this.url, {
+                jsonrpc: "2.0",
+                id: "1",
+                method,
+                params,
+            })
+            .then((resp) => {
+                if ("result" in resp.data) {
+                    return resp.data["result"];
+                } else if ("error" in resp.data) {
+                    // not wrapping in new Error to avoid printing as [Object object]
+                    throw resp.data["error"];
+                } else {
+                    throw resp.data;
+                }
+            })
+            .catch((err) => {
+                if (err.code === "ECONNABORTED") {
+                    throw new DevnetProviderError(
+                        `${err.message}. Try specifying a greater timeout in DevnetProvider({...})`,
+                    );
+                }
+                throw err;
+            });
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,3 +11,12 @@ export interface PredeployedAccount {
     public_key: string;
     address: string;
 }
+
+export class DevnetProviderError extends Error {
+    constructor(msg: string) {
+        super(msg);
+
+        // Set the prototype explicitly.
+        Object.setPrototypeOf(this, DevnetProviderError.prototype);
+    }
+}


### PR DESCRIPTION
- What the title says.
- Improve testing of the timeout config property.
- Mention config in README.md.