### PR TITLE
Fix minting large amounts

### DIFF
--- a/src/rpc-provider.ts
+++ b/src/rpc-provider.ts
@@ -28,9 +28,7 @@ export class RpcProvider {
             })
             .catch((err) => {
                 if (err.code === AxiosError.ECONNABORTED) {
-                    throw new DevnetProviderError(
-                        `${err.message}. Try specifying a greater timeout in DevnetProvider({...})`,
-                    );
+                    throw DevnetProviderError.fromAxiosError(err);
                 }
                 throw err;
             });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { AxiosError } from "axios";
+
 export type BigNumberish = string | number | bigint;
 
 export type BalanceUnit = "WEI" | "FRI";
@@ -18,5 +20,15 @@ export class DevnetProviderError extends Error {
 
         // Set the prototype explicitly.
         Object.setPrototypeOf(this, DevnetProviderError.prototype);
+    }
+
+    public static fromAxiosError(err: AxiosError) {
+        if (err.code === AxiosError.ECONNABORTED) {
+            return new DevnetProviderError(
+                `${err.message}. Try specifying a greater timeout in DevnetProvider({...})`,
+            );
+        }
+
+        throw new Error(`Cannot create a DevnetProviderError from ${err}`);
     }
 }

--- a/test/devnet-persistence.test.ts
+++ b/test/devnet-persistence.test.ts
@@ -10,7 +10,7 @@ describe("Devnet persistence", async function () {
     const DUMP_EXTENSION = ".dump.json";
 
     const DUMMY_ADDRESS = "0x1";
-    const DUMMY_AMOUNT = 20;
+    const DUMMY_AMOUNT = 20n;
 
     const devnetProvider = new DevnetProvider();
 

--- a/test/devnet-provider.test.ts
+++ b/test/devnet-provider.test.ts
@@ -7,7 +7,7 @@ describe("DevnetProvider", function () {
     const starknetProvider = new starknet.RpcProvider({ nodeUrl: devnetProvider.url });
 
     const DUMMY_ADDRESS = "0x1";
-    const DUMMY_AMOUNT = 20;
+    const DUMMY_AMOUNT = 20n;
 
     beforeEach("restart the state", async function () {
         await devnetProvider.restart();
@@ -36,7 +36,7 @@ describe("DevnetProvider", function () {
         }
     });
 
-    function assertMintResp(resp: MintResponse, expectedAmount: number, expectedUnit: BalanceUnit) {
+    function assertMintResp(resp: MintResponse, expectedAmount: bigint, expectedUnit: BalanceUnit) {
         expect(resp.tx_hash).to.match(/^0x[0-9a-fA-F]+/);
         expect(resp.new_balance).to.equal(BigInt(expectedAmount));
         expect(resp.unit).to.equal(expectedUnit);
@@ -80,6 +80,18 @@ describe("DevnetProvider", function () {
                 },
                 strk: { amount: accountBefore.initial_balance, unit: "FRI" },
             });
+        });
+
+        it("works with large amount multiple of 10", async function () {
+            const amount = 10n ** 30n;
+            const resp = await devnetProvider.mint(DUMMY_ADDRESS, amount, "WEI");
+            assertMintResp(resp, amount, "WEI");
+        });
+
+        it("works with large amount with non-zero ones digit", async function () {
+            const amount = 10n ** 30n + 1n;
+            const resp = await devnetProvider.mint(DUMMY_ADDRESS, amount, "WEI");
+            assertMintResp(resp, amount, "WEI");
         });
     });
 


### PR DESCRIPTION
## Usage related changes

- Close #10 
- Change `amount` type from `number` to `bigint`.

## Development related changes

- Replace using `POST JSON-RPC /` with `"method": "devnet_mint"` to `POST /mint`.
  - Basically, the problem is also on the server-side: when using JSON-RPC, the number somehow gets converted to scientific notation.
  - Can be reverted once Devnet 0.1.3 is released
- Add `public static DevnetProviderError.fromAxiosError`

## Checklist:

-   [x] Applied formatting - `npm run format`
-   [x] No linter errors - `npm run lint`
-   [x] Performed code self-review
-   [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please prefer merging over rebasing
-   [x] Updated the docs if needed
-   [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-js/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-   [x] Updated the tests if needed; all passing - `npm test`
