### PR TITLE
Introduce Devnet spawning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,9 @@ jobs:
             image: ubuntu-2204:2024.01.2
         resource_class: xlarge
         environment:
+            DEVNET_VERSION: "0.1.2"
+            DEVNET_DIR: "/tmp"
+            DEVNET_PATH: "/tmp/starknet-devnet"
             FORKED_DEVNET_PORT: 5051
         steps:
             - checkout
@@ -37,12 +40,17 @@ jobs:
                   name: Spawn Devnet
                   command: |
                       docker run -d --network host --name devnet \
-                        shardlabs/starknet-devnet-rs:0.1.2 --state-archive-capacity full --dump-on exit --dump-path "dummy.dump.json"
+                        shardlabs/starknet-devnet-rs:${DEVNET_VERSION} --state-archive-capacity full --dump-on exit --dump-path "dummy.dump.json"
             - run:
                   name: Spawn Devnet forked from Mainnet
                   command: |
                       docker run -d --network host --name forked-devnet \
-                        shardlabs/starknet-devnet-rs:0.1.2 --port ${FORKED_DEVNET_PORT} --fork-network https://free-rpc.nethermind.io/mainnet-juno/v0_7
+                        shardlabs/starknet-devnet-rs:${DEVNET_VERSION} --port ${FORKED_DEVNET_PORT} --fork-network https://free-rpc.nethermind.io/mainnet-juno/v0_7
+            - run:
+                  name: Download precompiled Devnet
+                  command: |
+                      URL=https://github.com/0xSpaceShard/starknet-devnet-rs/releases/download/v${DEVNET_VERSION}/starknet-devnet-x86_64-unknown-linux-gnu.tar.gz
+                      curl -sSfL ${URL} | tar -xvz -C ${DEVNET_DIR}
             - run:
                   name: Spawn Anvil
                   command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,9 @@ jobs:
         resource_class: xlarge
         environment:
             DEVNET_VERSION: "0.1.2"
-            DEVNET_DIR: "/tmp"
-            DEVNET_PATH: "/tmp/devnet-ci-storage"
+            DEVNET_DIR: "/tmp/devnet-ci-storage"
+            # to avoid definition complications, when updating DEVNET_DIR, always update DEVNET_PATH (should be prefix)
+            DEVNET_PATH: "/tmp/devnet-ci-storage/starknet-devnet"
             FORKED_DEVNET_PORT: 5051
         steps:
             - checkout
@@ -50,6 +51,7 @@ jobs:
                   name: Download precompiled Devnet
                   command: |
                       URL=https://github.com/0xSpaceShard/starknet-devnet-rs/releases/download/v${DEVNET_VERSION}/starknet-devnet-x86_64-unknown-linux-gnu.tar.gz
+                      mkdir -p ${DEVNET_DIR}
                       curl -sSfL ${URL} | tar -xvz -C ${DEVNET_DIR}
             - run:
                   name: Spawn Anvil

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
         environment:
             DEVNET_VERSION: "0.1.2"
             DEVNET_DIR: "/tmp"
-            DEVNET_PATH: "/tmp/starknet-devnet"
+            DEVNET_PATH: "/tmp/devnet-ci-storage"
             FORKED_DEVNET_PORT: 5051
         steps:
             - checkout

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@
 -   [ ] No linter errors - `npm run lint`
 -   [ ] Performed code self-review
 -   [ ] Rebased to the latest commit of the target branch (or merged it into my branch)
-    -   Once you make the PR reviewable, please prefer merging over rebasing
+    -   Once you make the PR reviewable, please avoid force-pushing
 -   [ ] Updated the docs if needed
 -   [ ] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-js/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
 -   [ ] Updated the tests if needed; all passing - `npm test`

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ async function main() {
 }
 ```
 
-To use the latest version:
+To use the latest compatible version:
 
 ```typescript
 const devnet = await Devnet.spawnVersion("latest");
@@ -80,14 +80,14 @@ If you have a custom build of Devnet or have multiple custom versions present lo
 
 ```typescript
 // provide the command
-const devnet = await Devnet.spawnCommand("my-devnet-command");
+const devnet = await Devnet.spawnCommand("my-devnet-command", { ... });
 // or specify the path
-const devnet = await Devnet.spawnCommand("/path/to/my-devnet-command");
+const devnet = await Devnet.spawnCommand("/path/to/my-devnet-command", { ... });
 ```
 
 ### Killing
 
-Even though the Devnet subprocess automatically exits and releases the used resources on program end, you can send it a signal as needed:
+Even though the Devnet subprocess automatically exits and releases the used resources on program end, you can send it a signal if needed:
 
 ```typescript
 const devnet = await Devnet.spawnInstalled();
@@ -96,15 +96,22 @@ devnet.kill(...); // defaults to SIGTERM
 
 ## Connect to a running instance
 
-If there already is a running Devnet instance (e.g. in another terminal or in another JS/TS program), you can simply connect to it by importing `DevnetProvider`. [Read more about different ways of running Devnet](https://0xspaceshard.github.io/starknet-devnet-rs/docs/category/running).
+If there already is a running Devnet instance (e.g. in another terminal or in another JS/TS program), you can simply connect to it by importing `DevnetProvider`. [Read more](https://0xspaceshard.github.io/starknet-devnet-rs/docs/category/running) about different ways of running Devnet.
 
 ```typescript
 import { DevnetProvider } from "starknet-devnet";
+const devnet = new DevnetProvider(); // accepts an optional configuration object
+console.log(await devnet.isAlive()); // true
+```
 
-async function helloDevnet() {
-    const devnet = new DevnetProvider(); // accepts an optional configuration object
-    console.log(await devnet.isAlive()); // true
-}
+## Enabling Starknet API support
+
+Since this library only supports the [Devnet-specific API](https://0xspaceshard.github.io/starknet-devnet-rs/docs/api#devnet-api), to interact via [Starknet JSON-RPC API](https://0xspaceshard.github.io/starknet-devnet-rs/docs/api#starknet-api), use [starknet.js](https://www.starknetjs.com/):
+
+```typescript
+import * as starknet from "starknet";
+const devnet = await Devnet.spawnInstalled();
+const starknetProvider = new starknet.RpcProvider({ nodeUrl: devnet.provider.url });
 ```
 
 ## L1-L2 communication

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ const devnet = await Devnet.spawnVersion("latest");
 Assuming you have already installed Devnet and it is present in your environment's `PATH`, simply run:
 
 ```typescript
-const devnet = await Devnet.spawnDefaultCommand();
+const devnet = await Devnet.spawnInstalled();
 ```
 
 ### Specify Devnet arguments
@@ -56,7 +56,7 @@ const devnet = await Devnet.spawnDefaultCommand();
 You can use the same CLI arguments you would pass to a Devnet running in a terminal:
 
 ```typescript
-const devnet = await Devnet.spawnVersion("v0.1.2", { args: ["--predeployed-accounts", "3"] });
+const devnet = await Devnet.spawnInstalled({ args: ["--predeployed-accounts", "3"] });
 ```
 
 ### Redirect the output
@@ -66,7 +66,7 @@ By default, the spawned Devnet inherits the output streams of the main JS progra
 ```typescript
 import fs from "fs";
 const outputStream = fs.createWriteStream("devnet-out.txt");
-const devnet = await Devnet.spawnVersion("v0.1.2", {
+const devnet = await Devnet.spawnInstalled({
     stdout: outputStream,
     stderr: ...,
 });

--- a/README.md
+++ b/README.md
@@ -106,12 +106,18 @@ console.log(await devnet.isAlive()); // true
 
 ## Enabling Starknet API support
 
-Since this library only supports the [Devnet-specific API](https://0xspaceshard.github.io/starknet-devnet-rs/docs/api#devnet-api), to interact via [Starknet JSON-RPC API](https://0xspaceshard.github.io/starknet-devnet-rs/docs/api#starknet-api), use [starknet.js](https://www.starknetjs.com/):
+Since this library only supports the [Devnet-specific API](https://0xspaceshard.github.io/starknet-devnet-rs/docs/api#devnet-api), to interact via [Starknet JSON-RPC API](https://0xspaceshard.github.io/starknet-devnet-rs/docs/api#starknet-api), use [starknet.js](https://www.starknetjs.com/).
+
+E.g. to get the latest block after spawning Devnet, you would need to do:
 
 ```typescript
+import { Devnet } from "starknet-devnet";
 import * as starknet from "starknet";
+
 const devnet = await Devnet.spawnInstalled();
 const starknetProvider = new starknet.RpcProvider({ nodeUrl: devnet.provider.url });
+
+const block = await starknetProvider.getBlock("latest");
 ```
 
 ## L1-L2 communication

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ const devnet = await Devnet.spawnVersion("v0.1.2", {
     stdout: outputStream,
     stderr: ...,
 });
+// do stuff with devnet and then close the stream
 outputStream.end();
 ```
 
@@ -99,11 +100,11 @@ async function helloDevnet() {
 
 ## L1-L2 communication
 
-Assuming there is an L1 provider running (e.g. [anvil](https://github.com/foundry-rs/foundry/tree/master/crates/anvil)), use the `postman` property of `DevnetProvider` to achieve [L1-L2 communication](https://0xspaceshard.github.io/starknet-devnet-rs/docs/postman).
+Assuming there is an L1 provider running (e.g. [anvil](https://github.com/foundry-rs/foundry/tree/master/crates/anvil)), use the `postman` property of `DevnetProvider` to achieve [L1-L2 communication](https://0xspaceshard.github.io/starknet-devnet-rs/docs/postman). See [this example](https://github.com/0xSpaceShard/starknet-devnet-js/blob/master/test/postman.test.ts) for more info.
 
 ## Examples
 
-See the [`test` directory](https://github.com/0xSpaceShard/starknet-devnet-js/tree/master/test) for usage examples.
+See the [`test` directory](https://github.com/0xSpaceShard/starknet-devnet-js/tree/master/test) for more usage examples.
 
 ## Contribute
 
@@ -111,4 +112,4 @@ If you spot a problem or room for improvement, check if an issue for it [already
 
 ### Test
 
-Before running the tests with `npm test`, follow the steps defined in the [CI/CD config file](.circleci/config.yml). If your test relies on environment variables, load them with `getEnvVar`. Conversely, to find all environment variables that need to be set, search the repo for `getEnvVar`.
+Before running the tests with `npm test`, follow the steps defined in the [CI/CD config file](.circleci/config.yml). If your new test relies on environment variables, load them with `getEnvVar`. Conversely, to find all environment variables that need to be set before running existing tests, search the repo for `getEnvVar`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Introduction
 
-Using this JavaScript/TypeScript library, you can interact with [Starknet Devnet](https://github.com/0xSpaceShard/starknet-devnet-rs/) via its specific [Devnet API](https://0xspaceshard.github.io/starknet-devnet-rs/docs/api#devnet-api). To interact with any Starknet node or network (including Starknet Devnet) via the [Starknet JSON-RPC API](https://0xspaceshard.github.io/starknet-devnet-rs/docs/api#starknet-api), see [starknet.js](https://www.starknetjs.com/).
+Using this JavaScript/TypeScript library, you can spawn [Starknet Devnet](https://github.com/0xSpaceShard/starknet-devnet-rs/) without installing and running it in a separate terminal. You can interact with it via its specific [Devnet API](https://0xspaceshard.github.io/starknet-devnet-rs/docs/api#devnet-api). To interact with any Starknet node or network (including Starknet Devnet) via the [Starknet JSON-RPC API](https://0xspaceshard.github.io/starknet-devnet-rs/docs/api#starknet-api), see [starknet.js](https://www.starknetjs.com/).
 
 # Installation
 
@@ -14,11 +14,79 @@ $ npm i starknet-devnet
 
 This library is compatible with stable Devnet versions in the inclusive range: `v0.1.1`-`v0.1.2`.
 
-[Devnet's balance checking functionality](https://0xspaceshard.github.io/starknet-devnet-rs/docs/balance#check-balance) is not provided in this library because it is simply replaceable using starknet.js, as witnessed in [the tests](./test/util.ts#L53)
+[Devnet's balance checking functionality](https://0xspaceshard.github.io/starknet-devnet-rs/docs/balance#check-balance) is not provided in this library because it is simply replaceable using starknet.js, as witnessed by the [getAccountBalance function](./test/util.ts#L57)
 
 # Usage
 
-The main export of this package is `DevnetProvider`. Assuming you have a [running Devnet](https://0xspaceshard.github.io/starknet-devnet-rs/docs/category/running), simply import `DevnetProvider` in your JS/TS program and interact with the Devnet instance:
+## Spawn a new Devnet
+
+This library allows you to spawn a Devnet instance inside your script, without a separate terminal. It finds a free random free port, and releases all used resources on exit.
+
+### Spawn a version without manual installation
+
+Assuming your machine has a supported OS (macOS or Linux) and supported architecture (arm64/aarch64 or x64/x86_64), using `Devnet.spawnVersion` will quickly install and spawn a new Devnet.
+
+```typescript
+import { Devnet } from "starknet-devnet";
+
+async function main() {
+    // Specify anything from https://github.com/0xSpaceShard/starknet-devnet-rs/releases
+    // Be sure to include the 'v' if it's in the version name.
+    const devnet = await Devnet.spawnVersion("v0.1.2");
+    console.log(await devnet.provider.isAlive()); // true
+}
+```
+
+To use the latest version:
+
+```typescript
+const devnet = await Devnet.spawnVersion("latest");
+```
+
+### Spawn an already installed Devnet
+
+Assuming you have already installed Devnet and it is present in your environment's `PATH`, simply run:
+
+```typescript
+const devnet = await Devnet.spawnDefaultCommand();
+```
+
+### Specify Devnet arguments
+
+You can use the same CLI arguments you would pass to a Devnet running in a terminal:
+
+```typescript
+const devnet = await Devnet.spawnVersion("v0.1.2", { args: ["--predeployed-accounts", "3"] });
+```
+
+### Redirect the output
+
+By default, the spawned Devnet inherits the output streams of the main JS program in which it is invoked. If you invoke your program in a terminal without any stream redirections, it will print Devnet logs in that same terminal together with your program output. This can be overriden:
+
+```typescript
+import fs from "fs";
+const outputStream = fs.createWriteStream("devnet-out.txt");
+const devnet = await Devnet.spawnVersion("v0.1.2", {
+    stdout: outputStream,
+    stderr: ...,
+});
+outputStream.end();
+```
+
+### Spawn a custom build
+
+If you have a custom build of Devnet or have multiple custom versions present locally:
+
+```typescript
+// provide the command
+const devnet = await Devnet.spawnCommand("my-devnet-command");
+// or specify the path
+const devnet = await Devnet.spawnCommand("/path/to/my-devnet-command");
+```
+
+## Connect to a running instance
+
+If there already is a running Devnet instance (e.g. in another terminal or in another JS/TS program), you can simply connect to it by importing `DevnetProvider`. [Read more about different ways of running Devnet](https://0xspaceshard.github.io/starknet-devnet-rs/docs/category/running).
 
 ```typescript
 import { DevnetProvider } from "starknet-devnet";

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This library is compatible with stable Devnet versions in the inclusive range: `
 
 ## Spawn a new Devnet
 
-This library allows you to spawn a Devnet instance inside your script, without a separate terminal. It finds a free random free port, and releases all used resources on exit.
+This library allows you to spawn a Devnet instance inside your program, without a separate terminal. It finds a free random free port, and releases all used resources on exit.
 
 ### Spawn a version without manual installation
 
@@ -61,7 +61,7 @@ const devnet = await Devnet.spawnInstalled({ args: ["--predeployed-accounts", "3
 
 ### Redirect the output
 
-By default, the spawned Devnet inherits the output streams of the main JS program in which it is invoked. If you invoke your program in a terminal without any stream redirections, it will print Devnet logs in that same terminal together with your program output. This can be overriden:
+By default, the spawned Devnet inherits the output streams of the main program in which it is invoked. If you invoke your program in a terminal without any stream redirections, it will print Devnet logs in that same terminal together with your program output. This can be overriden:
 
 ```typescript
 import fs from "fs";
@@ -83,6 +83,15 @@ If you have a custom build of Devnet or have multiple custom versions present lo
 const devnet = await Devnet.spawnCommand("my-devnet-command");
 // or specify the path
 const devnet = await Devnet.spawnCommand("/path/to/my-devnet-command");
+```
+
+### Killing
+
+Even though the Devnet subprocess automatically exits and releases the used resources on program end, you can send it a signal as needed:
+
+```typescript
+const devnet = await Devnet.spawnInstalled();
+devnet.kill(...); // defaults to SIGTERM
 ```
 
 ## Connect to a running instance

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
             "version": "0.0.5",
             "license": "MIT",
             "dependencies": {
-                "axios": "^1.7.2"
+                "axios": "^1.7.2",
+                "decompress": "^4.2.1",
+                "decompress-targz": "^4.1.1"
             },
             "devDependencies": {
                 "@types/chai": "^4.2.22",
@@ -784,6 +786,25 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
         "node_modules/binary-extensions": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -794,6 +815,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/bl": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+            "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
+            "dependencies": {
+                "readable-stream": "^2.3.5",
+                "safe-buffer": "^5.1.1"
             }
         },
         "node_modules/brace-expansion": {
@@ -822,6 +852,56 @@
             "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
             "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
+        },
+        "node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+            }
+        },
+        "node_modules/buffer-alloc": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+            "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+            "dependencies": {
+                "buffer-alloc-unsafe": "^1.1.0",
+                "buffer-fill": "^1.0.0"
+            }
+        },
+        "node_modules/buffer-alloc-unsafe": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+            "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+        },
+        "node_modules/buffer-crc32": {
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/buffer-fill": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+            "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ=="
         },
         "node_modules/callsites": {
             "version": "3.1.0",
@@ -982,6 +1062,11 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        },
         "node_modules/common-tags": {
             "version": "1.8.2",
             "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
@@ -996,6 +1081,11 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true
+        },
+        "node_modules/core-util-is": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
         },
         "node_modules/create-require": {
             "version": "1.1.1",
@@ -1044,6 +1134,95 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/decompress": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
+            "integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
+            "dependencies": {
+                "decompress-tar": "^4.0.0",
+                "decompress-tarbz2": "^4.0.0",
+                "decompress-targz": "^4.0.0",
+                "decompress-unzip": "^4.0.1",
+                "graceful-fs": "^4.1.10",
+                "make-dir": "^1.0.0",
+                "pify": "^2.3.0",
+                "strip-dirs": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/decompress-tar": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
+            "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+            "dependencies": {
+                "file-type": "^5.2.0",
+                "is-stream": "^1.1.0",
+                "tar-stream": "^1.5.2"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/decompress-tarbz2": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
+            "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+            "dependencies": {
+                "decompress-tar": "^4.1.0",
+                "file-type": "^6.1.0",
+                "is-stream": "^1.1.0",
+                "seek-bzip": "^1.0.5",
+                "unbzip2-stream": "^1.0.9"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/decompress-tarbz2/node_modules/file-type": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
+            "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/decompress-targz": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
+            "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+            "dependencies": {
+                "decompress-tar": "^4.1.1",
+                "file-type": "^5.2.0",
+                "is-stream": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/decompress-unzip": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
+            "integrity": "sha512-1fqeluvxgnn86MOh66u8FjbtJpAFv5wgCT9Iw8rcBqQcCo5tO8eiJw7NNTrvt9n4CRBVq7CstiS922oPgyGLrw==",
+            "dependencies": {
+                "file-type": "^3.8.0",
+                "get-stream": "^2.2.0",
+                "pify": "^2.3.0",
+                "yauzl": "^2.4.2"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/decompress-unzip/node_modules/file-type": {
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+            "integrity": "sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/deep-eql": {
@@ -1116,6 +1295,14 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true
+        },
+        "node_modules/end-of-stream": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+            "dependencies": {
+                "once": "^1.4.0"
+            }
         },
         "node_modules/escalade": {
             "version": "3.1.2",
@@ -1404,6 +1591,14 @@
                 "reusify": "^1.0.4"
             }
         },
+        "node_modules/fd-slicer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+            "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+            "dependencies": {
+                "pend": "~1.2.0"
+            }
+        },
         "node_modules/fetch-cookie": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-3.0.1.tgz",
@@ -1424,6 +1619,14 @@
             },
             "engines": {
                 "node": "^10.12.0 || >=12.0.0"
+            }
+        },
+        "node_modules/file-type": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+            "integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==",
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/fill-range": {
@@ -1515,6 +1718,11 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/fs-constants": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+        },
         "node_modules/fs-extra": {
             "version": "10.1.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -1560,6 +1768,18 @@
             "dev": true,
             "dependencies": {
                 "@starknet-io/types-js": "^0.7.7"
+            }
+        },
+        "node_modules/get-stream": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+            "integrity": "sha512-AUGhbbemXxrZJRD5cDvKtQxLuYaIbNtDTK8YqupCI393Q2KSTreEsLUN3ZxAWFGiKTzL6nKuzfcIvieflUX9qA==",
+            "dependencies": {
+                "object-assign": "^4.0.1",
+                "pinkie-promise": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/glob": {
@@ -1655,8 +1875,7 @@
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-            "dev": true
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
         },
         "node_modules/graphemer": {
             "version": "1.4.0",
@@ -1702,6 +1921,25 @@
             "bin": {
                 "he": "bin/he"
             }
+        },
+        "node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
         },
         "node_modules/ignore": {
             "version": "5.3.1",
@@ -1760,8 +1998,7 @@
         "node_modules/inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
@@ -1805,6 +2042,11 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-natural-number": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
+            "integrity": "sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ=="
+        },
         "node_modules/is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -1832,6 +2074,14 @@
                 "node": ">=8"
             }
         },
+        "node_modules/is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/is-unicode-supported": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -1843,6 +2093,11 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
         },
         "node_modules/isexe": {
             "version": "2.0.0",
@@ -2069,6 +2324,25 @@
                 "get-func-name": "^2.0.1"
             }
         },
+        "node_modules/make-dir": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+            "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+            "dependencies": {
+                "pify": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/make-dir/node_modules/pify": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+            "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/make-error": {
             "version": "1.3.6",
             "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -2283,11 +2557,18 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "dev": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -2402,6 +2683,11 @@
                 "node": "*"
             }
         },
+        "node_modules/pend": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
+        },
         "node_modules/picomatch": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -2412,6 +2698,33 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/pify": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/pinkie": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/pinkie-promise": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
+            "dependencies": {
+                "pinkie": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/prelude-ls": {
@@ -2617,6 +2930,11 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/process-nextick-args": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+        },
         "node_modules/proxy-from-env": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -2677,6 +2995,25 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
             "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
             "dev": true
+        },
+        "node_modules/readable-stream": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/readable-stream/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "node_modules/readdirp": {
             "version": "3.6.0",
@@ -2782,7 +3119,6 @@
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -2797,6 +3133,18 @@
                     "url": "https://feross.org/support"
                 }
             ]
+        },
+        "node_modules/seek-bzip": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
+            "integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
+            "dependencies": {
+                "commander": "^2.8.1"
+            },
+            "bin": {
+                "seek-bunzip": "bin/seek-bunzip",
+                "seek-table": "bin/seek-bzip-table"
+            }
         },
         "node_modules/semver": {
             "version": "7.6.2",
@@ -2908,6 +3256,19 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
+        "node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/string_decoder/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
         "node_modules/string-width": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -2934,6 +3295,14 @@
                 "node": ">=8"
             }
         },
+        "node_modules/strip-dirs": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
+            "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+            "dependencies": {
+                "is-natural-number": "^4.0.1"
+            }
+        },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -2958,11 +3327,38 @@
                 "node": ">=8"
             }
         },
+        "node_modules/tar-stream": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+            "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+            "dependencies": {
+                "bl": "^1.0.0",
+                "buffer-alloc": "^1.2.0",
+                "end-of-stream": "^1.0.0",
+                "fs-constants": "^1.0.0",
+                "readable-stream": "^2.3.0",
+                "to-buffer": "^1.1.1",
+                "xtend": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
         "node_modules/text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true
+        },
+        "node_modules/through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+        },
+        "node_modules/to-buffer": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+            "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
@@ -3128,6 +3524,15 @@
                 "node": ">=14.17"
             }
         },
+        "node_modules/unbzip2-stream": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+            "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+            "dependencies": {
+                "buffer": "^5.2.1",
+                "through": "^2.3.8"
+            }
+        },
         "node_modules/undici-types": {
             "version": "5.26.5",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -3167,6 +3572,11 @@
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
             }
+        },
+        "node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
         },
         "node_modules/v8-compile-cache-lib": {
             "version": "3.0.1",
@@ -3270,8 +3680,7 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "dev": true
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
         },
         "node_modules/ws": {
             "version": "8.17.1",
@@ -3292,6 +3701,14 @@
                 "utf-8-validate": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/xtend": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+            "engines": {
+                "node": ">=0.4"
             }
         },
         "node_modules/y18n": {
@@ -3343,6 +3760,15 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/yauzl": {
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+            "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+            "dependencies": {
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.1.0"
             }
         },
         "node_modules/yn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
                 "@types/chai": "^4.2.22",
                 "@types/mocha": "^9.1.1",
                 "@types/node": "^20.3.1",
+                "@types/tmp": "^0.2.6",
                 "@typescript-eslint/eslint-plugin": "^7.13.1",
                 "chai": "^4.3.7",
                 "eslint": "^8.57.0",
@@ -25,6 +26,7 @@
                 "mocha": "^10.2.0",
                 "prettier-eslint": "^16.3.0",
                 "starknet": "~6.9.0",
+                "tmp": "^0.2.3",
                 "ts-node": "^10.9.1",
                 "typescript": "^5.0.4"
             }
@@ -387,6 +389,12 @@
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
+        },
+        "node_modules/@types/tmp": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
+            "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
+            "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "7.13.1",
@@ -3362,6 +3370,15 @@
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+        },
+        "node_modules/tmp": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+            "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+            "dev": true,
+            "engines": {
+                "node": ">=14.14"
+            }
         },
         "node_modules/to-buffer": {
             "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.0.5",
             "license": "MIT",
             "dependencies": {
+                "@types/decompress": "^4.2.7",
                 "axios": "^1.7.2",
                 "decompress": "^4.2.1",
                 "decompress-targz": "^4.1.1"
@@ -365,6 +366,14 @@
             "integrity": "sha512-PatH4iOdyh3MyWtmHVFXLWCCIhUbopaltqddG9BzB+gMIzee2MJrvd+jouii9Z3wzQJruGWAm7WOMjgfG8hQlQ==",
             "dev": true
         },
+        "node_modules/@types/decompress": {
+            "version": "4.2.7",
+            "resolved": "https://registry.npmjs.org/@types/decompress/-/decompress-4.2.7.tgz",
+            "integrity": "sha512-9z+8yjKr5Wn73Pt17/ldnmQToaFHZxK0N1GHysuk/JIPT8RIdQeoInM01wWPgypRcvb6VH1drjuFpQ4zmY437g==",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/mocha": {
             "version": "9.1.1",
             "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
@@ -375,7 +384,6 @@
             "version": "20.14.7",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.7.tgz",
             "integrity": "sha512-uTr2m2IbJJucF3KUxgnGOZvYbN0QgkGyWxG6973HCpMYFy2KfcgYuIwkJQMQkt1VbBMlvWRbpshFTLxnxCZjKQ==",
-            "dev": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -3536,8 +3544,7 @@
         "node_modules/undici-types": {
             "version": "5.26.5",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-            "dev": true
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
         },
         "node_modules/universalify": {
             "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     ],
     "license": "MIT",
     "dependencies": {
-        "axios": "^1.7.2"
+        "axios": "^1.7.2",
+        "decompress": "^4.2.1",
+        "decompress-targz": "^4.1.1"
     },
     "devDependencies": {
         "@types/chai": "^4.2.22",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "@types/chai": "^4.2.22",
         "@types/mocha": "^9.1.1",
         "@types/node": "^20.3.1",
+        "@types/tmp": "^0.2.6",
         "@typescript-eslint/eslint-plugin": "^7.13.1",
         "chai": "^4.3.7",
         "eslint": "^8.57.0",
@@ -48,6 +49,7 @@
         "mocha": "^10.2.0",
         "prettier-eslint": "^16.3.0",
         "starknet": "~6.9.0",
+        "tmp": "^0.2.3",
         "ts-node": "^10.9.1",
         "typescript": "^5.0.4"
     }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     ],
     "license": "MIT",
     "dependencies": {
+        "@types/decompress": "^4.2.7",
         "axios": "^1.7.2",
         "decompress": "^4.2.1",
         "decompress-targz": "^4.1.1"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,8 @@
+/** milliseconds */
+export const DEFAULT_HTTP_TIMEOUT = 30_000;
+
+export const DEFAULT_DEVNET_HOST = "127.0.0.1";
+export const DEFAULT_DEVNET_PORT = 5050;
+export const DEFAULT_DEVNET_URL = `http://${DEFAULT_DEVNET_HOST}:${DEFAULT_DEVNET_PORT}`;
+
+export const LATEST_COMPATIBLE_DEVNET_VERSION = "v0.1.2";

--- a/src/devnet-provider.ts
+++ b/src/devnet-provider.ts
@@ -3,12 +3,7 @@ import { Postman } from "./postman";
 import { Cheats } from "./cheats";
 import { RpcProvider } from "./rpc-provider";
 import { BalanceUnit, DevnetProviderError, PredeployedAccount } from "./types";
-
-/** milliseconds */
-const DEFAULT_HTTP_TIMEOUT = 30_000;
-export const DEFAULT_DEVNET_HOST = "127.0.0.1";
-export const DEFAULT_DEVNET_PORT = 5050;
-const DEFAULT_DEVNET_URL = `http://${DEFAULT_DEVNET_HOST}:${DEFAULT_DEVNET_PORT}`;
+import { DEFAULT_DEVNET_URL, DEFAULT_HTTP_TIMEOUT } from "./constants";
 
 export type DevnetProviderConfig = {
     url?: string;

--- a/src/devnet-provider.ts
+++ b/src/devnet-provider.ts
@@ -6,7 +6,9 @@ import { BalanceUnit, DevnetProviderError, PredeployedAccount } from "./types";
 
 /** milliseconds */
 const DEFAULT_HTTP_TIMEOUT = 30_000;
-const DEFAULT_DEVNET_URL = "http://127.0.0.1:5050";
+export const DEFAULT_DEVNET_HOST = "127.0.0.1";
+export const DEFAULT_DEVNET_PORT = 5050;
+const DEFAULT_DEVNET_URL = `http://${DEFAULT_DEVNET_HOST}:${DEFAULT_DEVNET_PORT}`;
 
 export type DevnetProviderConfig = {
     url?: string;

--- a/src/devnet.ts
+++ b/src/devnet.ts
@@ -10,10 +10,12 @@ import {
 import { VersionHandler } from "./version-handler";
 import { Stream } from "stream";
 
+export type DevnetOutput = "inherit" | Stream | number;
+
 export interface DevnetConfig {
     args?: string[];
-    stdout?: "inherit" | Stream | number;
-    stderr?: "inherit" | Stream | number;
+    stdout?: DevnetOutput;
+    stderr?: DevnetOutput;
     maxStartupMillis?: number;
 }
 

--- a/src/devnet.ts
+++ b/src/devnet.ts
@@ -13,9 +13,11 @@ import { Stream } from "stream";
 export type DevnetOutput = "inherit" | Stream | number;
 
 export interface DevnetConfig {
+    /** The CLI args you would pass to a Devnet run in terminal. */
     args?: string[];
     stdout?: DevnetOutput;
     stderr?: DevnetOutput;
+    /** The maximum amount of time waited for Devnet to start. */
     maxStartupMillis?: number;
 }
 
@@ -79,7 +81,7 @@ export class Devnet {
 
     /**
      * Spawns a new Devnet using the provided command and optional args in `config`.
-     * If you don't have a local Devnet, but know the version you would like to run, use {@link spawnCommand}.
+     * If you don't have a local Devnet, but know the version you would like to run, use {@link spawnVersion}.
      * @param command the command used for starting Devnet; can be a path
      * @param config configuration object
      * @returns a newly spawned Devnet instance
@@ -144,7 +146,8 @@ The output location is configurable via the config object passed to the Devnet s
         }
 
         throw new DevnetError(
-            "Could not spawn Devnet! Ensure that you can spawn using the chosen method or increase the startup time.",
+            "Could not spawn Devnet! Ensure that you can spawn using the chosen method. \
+Alternatively, increase the startup time defined in the config object provided on spawning.",
         );
     }
 

--- a/src/devnet.ts
+++ b/src/devnet.ts
@@ -71,17 +71,17 @@ export class Devnet {
     ) {}
 
     /**
-     * Assumes `starknet-devnet` is installed and present in the environment PATH and executes it.
+     * Assumes `starknet-devnet` is installed and present in the environment PATH and executes it, using the args provided in `config`.
      * @param config an object for configuring Devnet
      * @returns a newly spawned Devnet instance
      */
-    static async spawnDefaultCommand(config: DevnetConfig = {}): Promise<Devnet> {
+    static async spawnInstalled(config: DevnetConfig = {}): Promise<Devnet> {
         return this.spawnCommand("starknet-devnet", config);
     }
 
     /**
      * Spawns a new Devnet using the provided command and optional args in `config`.
-     * If you don't have a local Devnet, but know the version you would like to run, use {@link spawnVersion}.
+     * The `command` can be an absolute or a relative path, or a command in your environment's PATH.
      * @param command the command used for starting Devnet; can be a path
      * @param config configuration object
      * @returns a newly spawned Devnet instance
@@ -119,7 +119,8 @@ The output location is configurable via the config object passed to the Devnet s
     }
 
     /**
-     * Spawns a Devnet of the provided version. If not present locally, fetches it.
+     * Spawns a Devnet of the provided `version` using the parameters provided in `config`.
+     * If not present locally, a precompiled version is fetched, extracted and executed.
      * If you already have a local Devnet you would like to run, use {@link spawnCommand}.
      * @param version if set to `"latest"`, uses the latest Devnet version compatible with this library;
      *     otherwise needs to be a semver string with a prepended "v" (e.g. "v1.2.3") and

--- a/src/devnet.ts
+++ b/src/devnet.ts
@@ -69,11 +69,11 @@ export class Devnet {
     ) {}
 
     /**
-     * Assumes there is a `starknet-devnet` present in the environment and executes it.
+     * Assumes `starknet-devnet` is installed and present in the environment PATH and executes it.
      * @param config an object for configuring Devnet
      * @returns a newly spawned Devnet instance
      */
-    static async spawn(config: DevnetConfig = {}): Promise<Devnet> {
+    static async spawnDefaultCommand(config: DevnetConfig = {}): Promise<Devnet> {
         return this.spawnCommand("starknet-devnet", config);
     }
 

--- a/src/devnet.ts
+++ b/src/devnet.ts
@@ -1,0 +1,124 @@
+import { ChildProcess, spawn as spawnChildProcess } from "child_process";
+import { DevnetProvider, DEFAULT_DEVNET_PORT, DEFAULT_DEVNET_HOST } from "./devnet-provider";
+import { DevnetError } from "./types";
+import { isFreePort, sleep } from "./util";
+
+export interface DevnetConfig {
+    args?: string[];
+    output?: string;
+    maxStartupMillis?: number;
+}
+
+/**
+ * Attempt to extract the URL from the provided Devnet CLI args. If host or present not present,
+ * populates the received array with default values. The host defaults to 127.0.0.1 and the port
+ * is randomly assigned.
+ * @param args CLI args to Devnet
+ * @returns the URL enabling communication with the Devnet instance
+ */
+async function ensureUrl(args: string[]): Promise<string> {
+    let host: string;
+    const hostParamIndex = args.indexOf("--host");
+    if (hostParamIndex === -1) {
+        host = DEFAULT_DEVNET_HOST;
+        args.push(...["--host", host]);
+    } else {
+        host = args[hostParamIndex + 1];
+    }
+
+    let port: string;
+    const portParamIndex = args.indexOf("--port");
+    if (portParamIndex === -1) {
+        port = await getFreePort();
+        args.push(...["--port", port]);
+    } else {
+        port = args[portParamIndex + 1];
+    }
+
+    return `http://${host}:${port}`;
+}
+
+async function ensureAlive(provider: DevnetProvider, maxStartupMillis: number): Promise<void> {
+    const checkPeriod = 100; // ms
+    const maxIterations = maxStartupMillis / checkPeriod;
+
+    for (let i = 0; i < maxIterations; ++i) {
+        if (await provider.isAlive()) {
+            return;
+        }
+        await sleep(checkPeriod);
+    }
+
+    throw new DevnetError(
+        "Could not spawn Devnet! Ensure that you can spawn using the chosen method or increase the startup time.",
+    );
+}
+
+async function getFreePort(): Promise<string> {
+    const step = 1000;
+    const maxPort = 65535;
+    for (let port = DEFAULT_DEVNET_PORT + step; port <= maxPort; port += step) {
+        if (await isFreePort(port)) {
+            return port.toString();
+        }
+    }
+
+    throw new DevnetError("Could not find a free port! Try rerunning your command.");
+}
+
+export class Devnet {
+    static instances: Devnet[] = [];
+
+    private constructor(
+        private process: ChildProcess,
+        public provider: DevnetProvider,
+    ) {}
+
+    static async spawn(config: DevnetConfig = {}): Promise<Devnet> {
+        return this.spawnCommand("starknet-devnet", config);
+    }
+
+    static async spawnCommand(command: string, config: DevnetConfig = {}): Promise<Devnet> {
+        const args = config.args || [];
+        const devnetUrl = await ensureUrl(args);
+
+        const devnetProcess = spawnChildProcess(command, args, {
+            detached: true,
+            stdio: "inherit",
+        });
+        devnetProcess.unref();
+
+        const devnetInstance = new Devnet(devnetProcess, new DevnetProvider({ url: devnetUrl }));
+        // store it now to ensure it's cleaned up automatically if the remaining steps fail
+        Devnet.instances.push(devnetInstance);
+
+        await ensureAlive(devnetInstance.provider, config?.maxStartupMillis ?? 5000);
+        return devnetInstance;
+    }
+
+    static async spawnVersion(_version: string, _config: DevnetConfig = {}): Promise<Devnet> {
+        // get the right artifact according to platform and os
+        throw new Error("Not implemented");
+    }
+
+    /**
+     * Sends the provided signal to the underlying Devnet process.
+     * @param signal the signal to be sent; deaults to `SIGTERM`
+     * @returns `true` if successful; `false` otherwise
+     */
+    public kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
+        return this.process.kill(signal);
+    }
+
+    static cleanup() {
+        for (const instance of Devnet.instances) {
+            if (!instance.process.killed) {
+                instance.kill();
+            }
+        }
+    }
+}
+
+for (const event of ["exit", "SIGINT", "SIGTERM", "SIGQUIT", "uncaughtException"]) {
+    process.on(event, Devnet.cleanup);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
+export * from "./devnet";
 export * from "./devnet-provider";
 export * from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ export class DevnetProviderError extends Error {
 
     public static fromAxiosError(err: AxiosError) {
         if (err.code === AxiosError.ECONNABORTED) {
-            return new DevnetProviderError(
+            return new this(
                 `${err.message}. Try specifying a greater timeout in DevnetProvider({...})`,
             );
         }
@@ -36,6 +36,15 @@ export class DevnetProviderError extends Error {
 export class DevnetError extends Error {
     constructor(msg: string) {
         super(msg);
+
+        // Set the prototype explicitly.
+        Object.setPrototypeOf(this, DevnetError.prototype);
+    }
+}
+
+export class GithubError extends Error {
+    constructor(msg: string) {
+        super(`Unexpected response from GitHub: ${msg}`);
 
         // Set the prototype explicitly.
         Object.setPrototypeOf(this, DevnetError.prototype);

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,3 +32,12 @@ export class DevnetProviderError extends Error {
         throw new Error(`Cannot create a DevnetProviderError from ${err}`);
     }
 }
+
+export class DevnetError extends Error {
+    constructor(msg: string) {
+        super(msg);
+
+        // Set the prototype explicitly.
+        Object.setPrototypeOf(this, DevnetError.prototype);
+    }
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,23 @@
+import net from "net";
+
+export async function sleep(millis: number): Promise<void> {
+    await new Promise((resolve, _) => setTimeout(resolve, millis));
+}
+
+export function isFreePort(port: number): Promise<boolean> {
+    return new Promise((accept, reject) => {
+        const sock = net.createConnection(port);
+        sock.once("connect", () => {
+            sock.end();
+            accept(false);
+        });
+        sock.once("error", (e: NodeJS.ErrnoException) => {
+            sock.destroy();
+            if (e.code === "ECONNREFUSED") {
+                accept(true);
+            } else {
+                reject(e);
+            }
+        });
+    });
+}

--- a/src/version-handler.ts
+++ b/src/version-handler.ts
@@ -1,0 +1,148 @@
+import axios, { AxiosInstance } from "axios";
+import path from "path";
+import fs from "fs";
+import os from "os";
+import { DEFAULT_HTTP_TIMEOUT } from "./constants";
+import { DevnetError, GithubError } from "./types";
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const decompress = require("decompress");
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const decompressTargz = require("decompress-targz");
+
+export class VersionHandler {
+    static httpProvider: AxiosInstance = axios.create({
+        timeout: DEFAULT_HTTP_TIMEOUT,
+    });
+
+    static localStoragePath: string = path.join(os.tmpdir(), "devnet-versions");
+
+    private static getVersionDir(version: string): string {
+        return path.join(this.localStoragePath, version);
+    }
+
+    private static getExecutablePath(versionDir: string): string {
+        return path.join(versionDir, "starknet-devnet");
+    }
+
+    /**
+     * Ensure that the command corresponding to the provided `version` exists.
+     * @param version semver string with a prepended "v";
+     *      should be available in https://github.com/0xSpaceShard/starknet-devnet-rs/releases
+     * @returns the path to the executable corresponding to the version
+     */
+    static async getExecutable(version: string): Promise<string> {
+        const versionDir = this.getVersionDir(version);
+        const executable = this.getExecutablePath(versionDir);
+        if (fs.existsSync(executable)) {
+            return executable;
+        }
+
+        const executableUrl = await this.getArchivedExecutableUrl(version);
+        const archivePath = await this.fetchArchivedExecutable(executableUrl, versionDir);
+        await this.extract(archivePath, versionDir);
+        return executable;
+    }
+
+    private static getCompatibleArch(): string {
+        switch (process.arch) {
+            case "arm64":
+                return "aarch64";
+            case "x64":
+                return "x86_64";
+            default:
+                throw new DevnetError(`Incompatible architecture: ${process.platform}`);
+        }
+    }
+
+    private static getCompatiblePlatform(): string {
+        switch (process.platform) {
+            case "linux":
+                return "linux-gnu";
+            case "darwin":
+                return "darwin";
+            default:
+                throw new DevnetError(`Incompatible platform: ${process.platform}`);
+        }
+    }
+
+    private static async getArchivedExecutableUrl(version: string): Promise<string> {
+        const releasesUrl = "https://api.github.com/repos/0xSpaceShard/starknet-devnet-rs/releases";
+        const releasesResp = await this.httpProvider.get(releasesUrl);
+
+        if (releasesResp.status !== axios.HttpStatusCode.Ok) {
+            throw new GithubError(releasesResp.statusText);
+        }
+
+        if (!Array.isArray(releasesResp.data)) {
+            throw new GithubError(`Invalid response: ${JSON.stringify(releasesResp.data)}`);
+        }
+
+        let versionPresent = false;
+        for (const release of releasesResp.data) {
+            if (release.name === version) {
+                versionPresent = true;
+                break;
+            }
+        }
+
+        if (!versionPresent) {
+            throw new GithubError(
+                `Version not found. If specifying an exact version, make sure you prepended the 'v' and that the version really exists in ${releasesUrl}.`,
+            );
+        }
+
+        const arch = this.getCompatibleArch();
+        const platform = this.getCompatiblePlatform();
+        return `https://github.com/0xSpaceShard/starknet-devnet-rs/releases/download/${version}/starknet-devnet-${arch}-unknown-${platform}.tar.gz`;
+    }
+
+    /**
+     * @param url the url of the archived executable
+     * @param versionDir the path to the directory where the archive will be written and extracted
+     * @returns the path where the archive was stored
+     */
+    private static async fetchArchivedExecutable(url: string, versionDir: string): Promise<string> {
+        const resp = await this.httpProvider.get(url, { responseType: "stream" });
+        if (resp.status === axios.HttpStatusCode.NotFound) {
+            throw new GithubError(`Not found: ${url}`);
+        } else if (resp.status !== axios.HttpStatusCode.Ok) {
+            throw new GithubError(resp.statusText);
+        }
+
+        if (!fs.existsSync(versionDir)) {
+            fs.mkdirSync(versionDir, { recursive: true });
+        }
+
+        const archivedExecutablePath = path.join(versionDir, "archive.tar.gz");
+        const writer = fs.createWriteStream(archivedExecutablePath);
+
+        return new Promise((resolve, reject) => {
+            resp.data.pipe(writer);
+
+            let error: Error;
+            writer.on("error", (e) => {
+                error = e;
+                writer.close();
+                reject(error);
+            });
+
+            writer.on("close", () => {
+                if (!error) {
+                    resolve(archivedExecutablePath);
+                }
+                // no need to call `reject` here, as it will have been called in the
+                // "error" stream;
+            });
+        });
+    }
+
+    /**
+     * Extract the content of the archive.
+     * @param archivePath the local path of the archive
+     */
+    private static async extract(archivePath: string, targetDir: string): Promise<void> {
+        await decompress(archivePath, targetDir, {
+            plugins: [decompressTargz()],
+        });
+    }
+}

--- a/src/version-handler.ts
+++ b/src/version-handler.ts
@@ -4,8 +4,7 @@ import fs from "fs";
 import os from "os";
 import { DEFAULT_HTTP_TIMEOUT } from "./constants";
 import { DevnetError, GithubError } from "./types";
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const decompress = require("decompress");
+import decompress from "decompress";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const decompressTargz = require("decompress-targz");
 

--- a/test/devnet-spawn.test.ts
+++ b/test/devnet-spawn.test.ts
@@ -1,0 +1,37 @@
+import { expect } from "chai";
+import { Devnet } from "..";
+import { getEnvVar, sleep } from "./util";
+
+describe("Devnet", function () {
+    this.timeout(5000);
+
+    let devnetPath: string;
+    before(function () {
+        devnetPath = getEnvVar("DEVNET_PATH");
+    });
+
+    it("should be spawnable via path and killable", async function () {
+        const devnet = await Devnet.spawnCommand(devnetPath);
+        expect(await devnet.provider.isAlive()).to.be.true;
+
+        // the subprocess is killed automatically on program exit,
+        // but here it is demonstrated that it can be killed on request
+        const success = devnet.kill();
+        expect(success).to.be.true;
+
+        // could work without the sleep, but on slower systems it needs some time to die in peae
+        await sleep(2000);
+
+        expect(await devnet.provider.isAlive()).to.be.false;
+    });
+
+    it("should spawn multiple Devnets at different ports", async function () {
+        const devnet = await Devnet.spawnCommand(devnetPath);
+        const anotherDevnet = await Devnet.spawnCommand(devnetPath);
+
+        expect(devnet.provider.url).to.not.be.equal(anotherDevnet.provider.url);
+
+        expect(await devnet.provider.isAlive()).to.be.true;
+        expect(await anotherDevnet.provider.isAlive()).to.be.true;
+    });
+});

--- a/test/devnet-spawn.test.ts
+++ b/test/devnet-spawn.test.ts
@@ -3,7 +3,7 @@ import { Devnet, DevnetProvider, GithubError } from "..";
 import { getEnvVar, sleep } from "./util";
 import path from "path";
 
-describe("Devnet", function () {
+describe("Spawnable Devnet", function () {
     this.timeout(5000);
 
     let devnetPath: string;
@@ -66,6 +66,16 @@ describe("Devnet", function () {
             assert.fail("Should have failed earlier");
         } catch (err) {
             expect(err).to.have.property("code").equal("ENOENT");
+        }
+    });
+
+    it("should fail if invalid CLI param", async function () {
+        try {
+            await Devnet.spawnCommand(devnetPath, { args: ["--faulty-param", "123"] });
+            assert.fail("Should have failed earlier");
+        } catch (err) {
+            expect(err).to.contain("Devnet exited");
+            expect(err).to.contain("Check Devnet's logged output");
         }
     });
 

--- a/test/devnet-spawn.test.ts
+++ b/test/devnet-spawn.test.ts
@@ -32,7 +32,7 @@ describe("Spawnable Devnet", function () {
         process.env.PATH += `:${devnetDir}`;
 
         // command expects Devnet to be available in PATH
-        const devnet = await Devnet.spawnDefaultCommand();
+        const devnet = await Devnet.spawnInstalled();
         expect(await devnet.provider.isAlive()).to.be.true;
     });
 

--- a/test/devnet-spawn.test.ts
+++ b/test/devnet-spawn.test.ts
@@ -32,7 +32,7 @@ describe("Spawnable Devnet", function () {
         process.env.PATH += `:${devnetDir}`;
 
         // command expects Devnet to be available in PATH
-        const devnet = await Devnet.spawn();
+        const devnet = await Devnet.spawnDefaultCommand();
         expect(await devnet.provider.isAlive()).to.be.true;
     });
 

--- a/test/devnet-spawn.test.ts
+++ b/test/devnet-spawn.test.ts
@@ -1,13 +1,37 @@
-import { expect } from "chai";
-import { Devnet } from "..";
+import { assert, expect } from "chai";
+import { Devnet, DevnetProvider, GithubError } from "..";
 import { getEnvVar, sleep } from "./util";
+import path from "path";
 
 describe("Devnet", function () {
     this.timeout(5000);
 
     let devnetPath: string;
+    let devnetVersion: string;
+    let oldEnv: NodeJS.ProcessEnv;
+
     before(function () {
+        // a predefined path corresponding to a Devnet executable
         devnetPath = getEnvVar("DEVNET_PATH");
+
+        // a semver string corresponding to a compatible Devnet version
+        devnetVersion = getEnvVar("DEVNET_VERSION");
+
+        // clone environment to later restore it; some tests may modify it
+        oldEnv = Object.assign({}, process.env);
+    });
+
+    afterEach(function () {
+        process.env = oldEnv;
+    });
+
+    it("should be spawnable by command in PATH", async function () {
+        const devnetDir = path.dirname(devnetPath);
+        process.env.PATH += `:${devnetDir}`;
+
+        // command expects Devnet to be available in PATH
+        const devnet = await Devnet.spawn();
+        expect(await devnet.provider.isAlive()).to.be.true;
     });
 
     it("should be spawnable via path and killable", async function () {
@@ -19,7 +43,7 @@ describe("Devnet", function () {
         const success = devnet.kill();
         expect(success).to.be.true;
 
-        // could work without the sleep, but on slower systems it needs some time to die in peae
+        // could work without the sleep, but on slower systems it needs some time to die in peace
         await sleep(2000);
 
         expect(await devnet.provider.isAlive()).to.be.false;
@@ -33,5 +57,76 @@ describe("Devnet", function () {
 
         expect(await devnet.provider.isAlive()).to.be.true;
         expect(await anotherDevnet.provider.isAlive()).to.be.true;
+    });
+
+    it("should fail if command does not exist", async function () {
+        const invalidCommand = "some-certainly-invald-command";
+        try {
+            await Devnet.spawnCommand(invalidCommand);
+            assert.fail("Should have failed earlier");
+        } catch (err) {
+            expect(err).to.have.property("code").equal("ENOENT");
+        }
+    });
+
+    it("should use the specified ports", async function () {
+        const dummyPort = 1234;
+
+        const provider = new DevnetProvider({ url: `http://127.0.0.1:${dummyPort}` });
+        expect(await provider.isAlive()).to.be.false;
+
+        const devnet = await Devnet.spawnCommand(devnetPath, {
+            args: ["--port", dummyPort.toString()],
+        });
+
+        expect(provider.url).to.equal(devnet.provider.url);
+        expect(await provider.isAlive()).to.be.true;
+    });
+
+    it("should pass CLI args", async function () {
+        const predeployedAccountsNumber = 13;
+        const initialBalance = "123";
+        const devnet = await Devnet.spawnCommand(devnetPath, {
+            args: [
+                "--accounts",
+                predeployedAccountsNumber.toString(),
+                "--initial-balance",
+                initialBalance,
+            ],
+        });
+
+        const predeployedAccounts = await devnet.provider.getPredeployedAccounts();
+        expect(predeployedAccounts).to.have.lengthOf(predeployedAccountsNumber);
+        expect(predeployedAccounts[0].initial_balance).to.equal(initialBalance);
+    });
+
+    it("should spawn by version", async function () {
+        const devnet = await Devnet.spawnVersion(`v${devnetVersion}`);
+        expect(await devnet.provider.isAlive()).to.be.true;
+    });
+
+    it("should spawn if specifying 'latest'", async function () {
+        const devnet = await Devnet.spawnVersion("latest");
+        expect(await devnet.provider.isAlive()).to.be.true;
+    });
+
+    it("should fail if missing 'v' in version specifier", async function () {
+        try {
+            await Devnet.spawnVersion(devnetVersion);
+            assert.fail("Should have failed earlier");
+        } catch (err) {
+            const typedErr = err as GithubError;
+            expect(typedErr.message).to.contain("Version not found");
+        }
+    });
+
+    it("should fail if version does not exist", async function () {
+        try {
+            await Devnet.spawnVersion("v1.2.345");
+            assert.fail("Should have failed earlier");
+        } catch (err) {
+            const typedErr = err as GithubError;
+            expect(typedErr.message).to.contain("Version not found");
+        }
     });
 });

--- a/test/util.ts
+++ b/test/util.ts
@@ -34,6 +34,10 @@ export function getEnvVar(varName: string): string {
     throw new Error(`Environment variable not defined: ${varName}`);
 }
 
+export async function sleep(millis: number): Promise<void> {
+    await new Promise((resolve, _) => setTimeout(resolve, millis));
+}
+
 export const ETH_TOKEN_CONTRACT_ADDRESS =
     "0x49D36570D4E46F48E99674BD3FCC84644DDD6B96F7C741B1562B82F9E004DC7";
 export const STRK_TOKEN_CONTRACT_ADDRESS =


### PR DESCRIPTION
## Usage related changes

- Introduces a spawnable `Devnet`. Read more in the docs.

## Development related changes

- This opens the possibility of replacing the background devnets configured in the CI (used in tests), to be replaced completely with this new Devnet feature.
- Introduce `src/constants.ts` and `src/util.ts`.
- Add a CI/CD step which installs pre-compiled Devnet.
- Add dependencies: `decompress`, `decompress-targz`, `tmp` (dev)

## Checklist:

-   [x] Applied formatting - `npm run format`
-   [x] No linter errors - `npm run lint`
-   [x] Performed code self-review
-   [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please prefer merging over rebasing
-   [x] Updated the docs if needed
-   [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-js/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-   [x] Updated the tests if needed; all passing - `npm test`
