### PR TITLE
Support keepAlive and expand docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,10 +50,9 @@ jobs:
             - run:
                   name: Download precompiled Devnet
                   command: |
+                      URL=https://github.com/0xSpaceShard/starknet-devnet-rs/releases/download/v${DEVNET_VERSION}/starknet-devnet-x86_64-unknown-linux-gnu.tar.gz
                       mkdir -p ${DEVNET_DIR}
                       curl -sSfL ${URL} | tar -xvz -C ${DEVNET_DIR}
-                  environment:
-                      URL: https://github.com/0xSpaceShard/starknet-devnet-rs/releases/download/v${DEVNET_VERSION}/starknet-devnet-x86_64-unknown-linux-gnu.tar.gz
             - run:
                   name: Spawn Anvil
                   command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,8 +64,6 @@ jobs:
             - run:
                   name: Test keepAlive
                   command: |
-                      PORT=9876
-
                       node -e 'require("./dist/devnet").Devnet.spawnVersion("latest", { args: ["--port", "'${PORT}'"] })'
                       curl -sSfL localhost:${PORT}/is_alive || echo "Ok... expected to be unresponsive"
 
@@ -74,6 +72,8 @@ jobs:
 
                       lsof -i :${PORT} | awk 'NR==2{print $2}' | xargs kill
                       curl -sSfL localhost:${PORT}/is_alive || echo "Ok... expected to be unresponsive"
+                  environment:
+                      PORT: 9876
     publish:
         docker:
             - image: cimg/node:20.10.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,20 @@ jobs:
             - run:
                   name: Test
                   command: npm run test
+            - run:
+                  name: Test keepAlive
+                  command: |
+                      PORT=9876
+                      healthcheck="curl -sSfL localhost:${PORT}/is_alive"
+
+                      node -e 'require("./dist/devnet").Devnet.spawnVersion("latest", { args: ["--port", "'${PORT}'"] })'
+                      "$healthcheck" || echo "Ok... expected to be unresponsive"
+
+                      node -e 'require("./dist/devnet").Devnet.spawnVersion("latest", { args: ["--port", "'${PORT}'"], keepAlive: true })'
+                      "$healthcheck"
+
+                      lsof -i :${PORT} | awk 'NR==2{print $2}' | xargs kill
+                      "$healthcheck" || echo "Ok... expected to be unresponsive"
     publish:
         docker:
             - image: cimg/node:20.10.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,16 +65,15 @@ jobs:
                   name: Test keepAlive
                   command: |
                       PORT=9876
-                      healthcheck="curl -sSfL localhost:${PORT}/is_alive"
 
                       node -e 'require("./dist/devnet").Devnet.spawnVersion("latest", { args: ["--port", "'${PORT}'"] })'
-                      "$healthcheck" || echo "Ok... expected to be unresponsive"
+                      curl -sSfL localhost:${PORT}/is_alive || echo "Ok... expected to be unresponsive"
 
                       node -e 'require("./dist/devnet").Devnet.spawnVersion("latest", { args: ["--port", "'${PORT}'"], keepAlive: true })'
-                      "$healthcheck"
+                      curl -sSfL localhost:${PORT}/is_alive
 
                       lsof -i :${PORT} | awk 'NR==2{print $2}' | xargs kill
-                      "$healthcheck" || echo "Ok... expected to be unresponsive"
+                      curl -sSfL localhost:${PORT}/is_alive || echo "Ok... expected to be unresponsive"
     publish:
         docker:
             - image: cimg/node:20.10.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,9 +50,10 @@ jobs:
             - run:
                   name: Download precompiled Devnet
                   command: |
-                      URL=https://github.com/0xSpaceShard/starknet-devnet-rs/releases/download/v${DEVNET_VERSION}/starknet-devnet-x86_64-unknown-linux-gnu.tar.gz
                       mkdir -p ${DEVNET_DIR}
                       curl -sSfL ${URL} | tar -xvz -C ${DEVNET_DIR}
+                  environment:
+                      URL: https://github.com/0xSpaceShard/starknet-devnet-rs/releases/download/v${DEVNET_VERSION}/starknet-devnet-x86_64-unknown-linux-gnu.tar.gz
             - run:
                   name: Spawn Anvil
                   command: |

--- a/README.md
+++ b/README.md
@@ -95,11 +95,26 @@ const devnet = await Devnet.spawnCommand("/path/to/my-devnet-command", { ... });
 
 ### Killing
 
-Even though the Devnet subprocess automatically exits and releases the used resources on program end, you can send it a signal if needed:
+By default, the Devnet subprocess automatically exits and releases the used resources on program end, but you can send it a signal if needed:
 
 ```typescript
 const devnet = await Devnet.spawnInstalled();
 devnet.kill(...); // defaults to SIGTERM
+```
+
+### Keeping alive
+
+To keep the spawned Devnet alive after your program exits, set the `keepAlive` flag:
+
+```typescript
+const devnet = await Devnet.spawnInstalled({ keepAlive: true });
+console.log("Devnet listening at", devnet.provider.url);
+```
+
+In that case, you must take care of the spawned process. E.g. if you wish to kill it, run the following command, substituting `PORT` with your Devnet's port:
+
+```
+$ lsof -i :${PORT} | awk 'NR==2{print $2}' | xargs kill
 ```
 
 ## Connect to a running instance

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ const devnet = await Devnet.spawnInstalled({
 outputStream.end();
 ```
 
-To track the output in a separate terminal, run:
+To track the output in a separate terminal, open a new terminal and run:
 
 ```
 $ tail -f devnet-out.txt
@@ -108,10 +108,9 @@ To keep the spawned Devnet alive after your program exits, set the `keepAlive` f
 
 ```typescript
 const devnet = await Devnet.spawnInstalled({ keepAlive: true });
-console.log("Devnet listening at", devnet.provider.url);
 ```
 
-In that case, you must take care of the spawned process. E.g. if you wish to kill it, run the following command, substituting `PORT` with your Devnet's port:
+In that case, you must take care of the spawned process. E.g. if you wish to kill it, run the following command, substituting `PORT` with your Devnet's port (the port is logged on Devnet startup, and is also a part of `devnet.provider.url`):
 
 ```
 $ lsof -i :${PORT} | awk 'NR==2{print $2}' | xargs kill

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ const devnet = await Devnet.spawnInstalled({
 outputStream.end();
 ```
 
+To track the output in a separate terminal, run:
+
+```
+$ tail -f devnet-out.txt
+```
+
 To ignore the output completely, specify `{ stdout: "ignore", stderr: "ignore" }`.
 
 ### Spawn a custom build

--- a/src/devnet.ts
+++ b/src/devnet.ts
@@ -17,8 +17,13 @@ export interface DevnetConfig {
     args?: string[];
     stdout?: DevnetOutput;
     stderr?: DevnetOutput;
-    /** The maximum amount of time waited for Devnet to start. */
+    /** The maximum amount of time waited for Devnet to start. Defaults to 5000 ms. */
     maxStartupMillis?: number;
+    /**
+     * If `false` (default), automatically closes the spawned Devnet on program exit.
+     * Otherwise keeps it alive.
+     */
+    keepAlive?: boolean;
 }
 
 /**
@@ -97,8 +102,11 @@ export class Devnet {
         devnetProcess.unref();
 
         const devnetInstance = new Devnet(devnetProcess, new DevnetProvider({ url: devnetUrl }));
-        // store it now to ensure it's cleaned up automatically if the remaining steps fail
-        Devnet.instances.push(devnetInstance);
+
+        if (!config.keepAlive) {
+            // store it now to ensure it's cleaned up automatically if the remaining steps fail
+            Devnet.instances.push(devnetInstance);
+        }
 
         return new Promise((resolve, reject) => {
             const maxStartupMillis = config?.maxStartupMillis ?? 5000;


### PR DESCRIPTION
## Usage related changes

- Config of `Devnet` constructors now supports `keepAlive: boolean` to keep the spawned Devnet alive after program exit.
- Expand docs with notes on:
  - killing an alive Devnet
  - tracking Devnet output in a separate terminal

## Development related changes

- The simplest way of testing the `keepAlive` feature was via a new step in config.yml

## Checklist:

-   [x] Applied formatting - `npm run format`
-   [x] No linter errors - `npm run lint`
-   [x] Performed code self-review
-   [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
-   [x] Updated the docs if needed
-   [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-js/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-   [x] Updated the tests if needed; all passing - `npm test`
