### PR TITLE
Fix Devnet binary fetching on mac (fix vendor)

### DIFF
--- a/src/version-handler.ts
+++ b/src/version-handler.ts
@@ -56,9 +56,9 @@ export class VersionHandler {
     private static getCompatiblePlatform(): string {
         switch (process.platform) {
             case "linux":
-                return "linux-gnu";
+                return "unknown-linux-gnu";
             case "darwin":
-                return "darwin";
+                return "apple-darwin";
             default:
                 throw new DevnetError(`Incompatible platform: ${process.platform}`);
         }
@@ -92,7 +92,7 @@ export class VersionHandler {
 
         const arch = this.getCompatibleArch();
         const platform = this.getCompatiblePlatform();
-        return `https://github.com/0xSpaceShard/starknet-devnet-rs/releases/download/${version}/starknet-devnet-${arch}-unknown-${platform}.tar.gz`;
+        return `https://github.com/0xSpaceShard/starknet-devnet-rs/releases/download/${version}/starknet-devnet-${arch}-${platform}.tar.gz`;
     }
 
     /**


### PR DESCRIPTION
## Usage related changes

- The archive-downloading logic was always using `unknown` as the vendor part of the build triplet. Now it's fixed to use `apple` for darwin (the only supported vendor), and `unknown` for `linux`.

## Development related changes

None

## Checklist:

-   [x] Applied formatting - `npm run format`
-   [x] No linter errors - `npm run lint`
-   [x] Performed code self-review
-   [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
-   [x] Updated the docs if needed
-   [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-js/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-   [x] Updated the tests if needed; all passing - `npm test`
