### PR TITLE
Move @types/decompress to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
             "version": "0.2.0",
             "license": "MIT",
             "dependencies": {
-                "@types/decompress": "^4.2.7",
                 "axios": "^1.7.4",
                 "decompress": "^4.2.1",
                 "decompress-targz": "^4.1.1"
             },
             "devDependencies": {
                 "@types/chai": "^4.2.22",
+                "@types/decompress": "^4.2.7",
                 "@types/mocha": "^9.1.1",
                 "@types/node": "^20.3.1",
                 "@types/tmp": "^0.2.6",
@@ -372,6 +372,8 @@
             "version": "4.2.7",
             "resolved": "https://registry.npmjs.org/@types/decompress/-/decompress-4.2.7.tgz",
             "integrity": "sha512-9z+8yjKr5Wn73Pt17/ldnmQToaFHZxK0N1GHysuk/JIPT8RIdQeoInM01wWPgypRcvb6VH1drjuFpQ4zmY437g==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
             }
@@ -386,6 +388,7 @@
             "version": "20.14.7",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.7.tgz",
             "integrity": "sha512-uTr2m2IbJJucF3KUxgnGOZvYbN0QgkGyWxG6973HCpMYFy2KfcgYuIwkJQMQkt1VbBMlvWRbpshFTLxnxCZjKQ==",
+            "dev": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -3561,7 +3564,8 @@
         "node_modules/undici-types": {
             "version": "5.26.5",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "dev": true
         },
         "node_modules/universalify": {
             "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -32,13 +32,13 @@
     ],
     "license": "MIT",
     "dependencies": {
-        "@types/decompress": "^4.2.7",
         "axios": "^1.7.4",
         "decompress": "^4.2.1",
         "decompress-targz": "^4.1.1"
     },
     "devDependencies": {
         "@types/chai": "^4.2.22",
+        "@types/decompress": "^4.2.7",
         "@types/mocha": "^9.1.1",
         "@types/node": "^20.3.1",
         "@types/tmp": "^0.2.6",


### PR DESCRIPTION
## Usage related changes

- Reduces production dependencies

## Development related changes

- Move `@types/decompress` to `devDependencies`.
  - The version of the dependency stays the same.

## Checklist:

-   [x] Applied formatting - `npm run format`
-   [x] No linter errors - `npm run lint`
-   [x] Performed code self-review
-   [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
-   [x] Updated the docs if needed
-   [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-js/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-   [x] Updated the tests if needed; all passing - `npm test`
