### PR TITLE
Update Devnet Docker image registry to starknetfoundation

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -50,14 +50,14 @@ jobs:
             - name: Start regular Devnet container
               run: |
                   docker run -d --network host --name devnet \
-                    shardlabs/starknet-devnet-rs:${DEVNET_VERSION} \
+                    starknetfoundation/starknet-devnet-rs:${DEVNET_VERSION} \
                     --state-archive-capacity full \
                     --dump-on request
 
             - name: Start Mainnet-forked Devnet container
               run: |
                   docker run -d --network host --name forked-devnet \
-                    shardlabs/starknet-devnet-rs:${DEVNET_VERSION} \
+                    starknetfoundation/starknet-devnet-rs:${DEVNET_VERSION} \
                     --port ${FORKED_DEVNET_PORT} \
                     --fork-network http://rpc.pathfinder.equilibrium.co/mainnet/rpc/v0_10
 


### PR DESCRIPTION
The Docker image has moved from `shardlabs/starknet-devnet-rs` to `starknetfoundation/starknet-devnet-rs`.